### PR TITLE
removing distributed from a comment in `toy_train.py`

### DIFF
--- a/examples/toy_train.py
+++ b/examples/toy_train.py
@@ -171,7 +171,7 @@ class Muon(torch.optim.Optimizer):
             wd = group["wd"]
             momentum = group["momentum"]
 
-            # generate weight updates in distributed fashion
+            # generate weight updates
             for p in params:
                 # sanity check
                 g = p.grad


### PR DESCRIPTION
Hello,
When we calc and apply the Muon update to the 2D parameters, the comment at the top of the loop iteration says:
`# generate weight updates in distributed fashion` which is a bit confusing since it's not distributed in this case/version.

I believe it was a remnant/artifact from your actual distributed Muon version that stayed there when you converted it for the toy example.